### PR TITLE
fixed a typo in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 name: Your Name
 
 # CUSTOMIZE
-# Short bio or description aout you (displayed in the header)
+# Short bio or description about you (displayed in the header)
 description: CSCI-UA 480 Student, Spring 2025
 
 # CUSTOMIZE


### PR DESCRIPTION
This is a PR for issue #1 
Changed "aout" to "about"
<img width="614" alt="截屏2025-02-25 23 50 16" src="https://github.com/user-attachments/assets/66dcdf70-633b-4861-badf-68a97a5f57cc" />
